### PR TITLE
Use correct domain in meta tag

### DIFF
--- a/src/containers/thread.js
+++ b/src/containers/thread.js
@@ -220,7 +220,7 @@ class Thread extends React.Component {
             <meta name="twitter:description" content={`Posted by ${content.author} on ${content.created} UTC.`} />
             <meta name="twitter:image:src" content={image} />
             <meta property="og:title" content={content.title} />
-            <meta property="og:url" content={`http://netify.chainbb.com/${(content.post && content.post.forum) ? content.post.forum._id : content.category}/@${content.author}/${content.permlink}`} />
+            <meta property="og:url" content={`http://chainbb.com/${(content.post && content.post.forum) ? content.post.forum._id : content.category}/@${content.author}/${content.permlink}`} />
             <meta property="og:description" content={`Posted by ${content.author} on ${content.created} UTC.`} />
         </Helmet>
         <Post


### PR DESCRIPTION
netify.chainbb.com, doesn't exist. It appears that it used to be some sort of testing domain, and is no longer active. It's still mentioned in a meta tag, though. This fixes it. Having the wrong meta tags will make Facebook and Twitter, the main users of Open Graph data, misunderstand, or be confused by, the meta tags on ChainBB. 
